### PR TITLE
fix(cd): remove warning of unused variable on windows builds

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,4 +1,8 @@
-use std::{env, fmt::Display, fs, process::Command};
+use std::env;
+use std::fmt::Display;
+#[cfg(unix)]
+use std::fs;
+use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 use spdlog::{debug, error};


### PR DESCRIPTION
Closes #31 